### PR TITLE
(InReview)音声ファイルリストの作成

### DIFF
--- a/DogCatch(ver1.01)/AppDelegate.h
+++ b/DogCatch(ver1.01)/AppDelegate.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "PlistLoad.h"
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 

--- a/DogCatch(ver1.01)/AppDelegate.m
+++ b/DogCatch(ver1.01)/AppDelegate.m
@@ -17,6 +17,10 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
+    
+    //audioデータ（plist）の読み込み
+    [PlistLoad loadPlist];
+    
     return YES;
 }
 

--- a/DogCatch(ver1.01)/AppDelegate.m
+++ b/DogCatch(ver1.01)/AppDelegate.m
@@ -19,7 +19,7 @@
     // Override point for customization after application launch.
     
     //audioデータ（plist）の読み込み
-    [PlistLoad loadPlist];
+    [PlistLoad loadAudioFilePlist];
     
     return YES;
 }

--- a/DogCatch(ver1.01)/Commons/SDAudioPlayerManager.h
+++ b/DogCatch(ver1.01)/Commons/SDAudioPlayerManager.h
@@ -55,6 +55,14 @@
  */
 - (AVAudioPlayer *)createPlayerWithFileName:(NSString *)fileName forKey:(NSString *)key;
 
+/**
+サウンドオブジェクトの生成(ファイル名)
+@param fileName resource（main bundle）にある任意のファイル名(拡張子付き)
+@param key サウンドオブジェクトの名前。nilを設定するとコンテナに保持しない。同じ名前の場合は上書きする。
+@param loop ループ回数の指定
+@return サウンドオブジェクトを生成して返す
+*/
+- (AVAudioPlayer *)createPlayerWithFileName:(NSString *)fileName forKey:(NSString *)key loop:(NSInteger)loop;
 
 /**
  サウンドオブジェクトの取得

--- a/DogCatch(ver1.01)/Commons/SDAudioPlayerManager.m
+++ b/DogCatch(ver1.01)/Commons/SDAudioPlayerManager.m
@@ -56,6 +56,13 @@
     return [self createPlayerWithURLString:pathString forKey:key];
 }
 
+- (AVAudioPlayer *)createPlayerWithFileName:(NSString *)fileName forKey:(NSString *)key loop:(NSInteger)loop
+{
+   AVAudioPlayer *player = [self createPlayerWithFileName:fileName forKey:key];
+    player.numberOfLoops = loop;
+    return player;
+}
+
 - (AVAudioPlayer *)playerWithKey:(NSString *)key
 {
     if (!key) {

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.h
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.h
@@ -13,7 +13,6 @@
 #import"TimerClass.h"
 #import"TitleScreenViewController.h"
 #import "BaseViewController.h"
-#import "SDAudioPlayerManager.h"
 
 @interface EasyModeViewController : BaseViewController<UIActionSheetDelegate>
 

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
@@ -58,8 +58,6 @@
 //Questionクラスのインスタンス
 @property (nonatomic,strong) Question *questionClassOBJ;
 
-@property (nonatomic,weak) AVAudioPlayer *player;
-
 @end
 
 @implementation EasyModeViewController

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
@@ -314,7 +314,6 @@
         [labelText2 appendString:@"いろだったの…"];
         [label2 setText:labelText2];
         
-        
         //⑦−2　設問パターンがNOの場合
     } else if(pattern == NO){
         
@@ -327,7 +326,6 @@
         [labelText2 appendString:wrongColorLabel];
         [labelText2 appendString:@"いろだったの…"];
         [label2 setText:labelText2];
-        
     }
 }
 

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
@@ -161,10 +161,8 @@
     //設問パターンをもとに、正解ボタンと失敗ボタンを生成し、同時に設問文の表示を行う
     [self decidedQuestion:self.isCompletelyMatchingPattern label1:self.questionColorLabel label2:self.questionActionLabel];
     
-    //音楽START！（ループは無限）
-    self.player = [AudioSingleton playerWithKey:@"ゲーム中"];
-    self.player.numberOfLoops = -1;
-    [self.player play];
+    //音楽START！
+    [AudioSingleton playAudioWithKey:@"ゲーム中"];
     
     //timer起動
 //    TimerClass *timerTest = [TimerClass alloc];

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
@@ -58,6 +58,8 @@
 //Questionクラスのインスタンス
 @property (nonatomic,strong) Question *questionClassOBJ;
 
+@property (nonatomic,weak) AVAudioPlayer *player;
+
 @end
 
 @implementation EasyModeViewController
@@ -151,7 +153,9 @@
     [self decidedQuestion:self.isCompletelyMatchingPattern label1:self.questionColorLabel label2:self.questionActionLabel];
     
     //音楽START！
-    [AudioSingleton playAudioWithKey:@"ゲーム中"];
+    self.player = [AudioSingleton playerWithKey:@"ゲーム中"];
+    self.player.numberOfLoops = -1;
+    [self.player play];
     
     //timer起動
 //    TimerClass *timerTest = [TimerClass alloc];
@@ -340,7 +344,7 @@
 
 -(void)timerStart
 {
-    self.timeCount = 10;
+    self.timeCount = 60;
     if(![self.timer isValid]){
         self.timer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(timer:) userInfo:nil repeats:YES];
     }
@@ -349,7 +353,6 @@
 //残り時間０以下でゲームを終了させる
 -(void)stopTimerForTimeOut:(CGFloat)count
 {
-    NSLog(@"countは%f",count);
     if (count <= 0) {
         [self.timer invalidate];
         [self clearGame:nil];
@@ -404,8 +407,6 @@
     //ボタンの円半径の設定を、画面変化に対応させる
     //        sender.layer.cornerRadius = (self.view.bounds.size.width / 2) * 1.0f;
     //            sender.layer.masksToBounds = YES;
-    
-
 }
 
 @end

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
@@ -152,7 +152,7 @@
     //設問パターンをもとに、正解ボタンと失敗ボタンを生成し、同時に設問文の表示を行う
     [self decidedQuestion:self.isCompletelyMatchingPattern label1:self.questionColorLabel label2:self.questionActionLabel];
     
-    //音楽START！
+    //音楽START！（ループは無限）
     self.player = [AudioSingleton playerWithKey:@"ゲーム中"];
     self.player.numberOfLoops = -1;
     [self.player play];

--- a/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
+++ b/DogCatch(ver1.01)/Controllers/EasyModeViewController.m
@@ -68,16 +68,25 @@
 #pragma mark - Private Methods
 
 //初期化
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    
+    if (self) {
+        
+        self.currentScore = 0;
+        self.questionClassOBJ = [[Question alloc]init];
+    }
+    
+    return self;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
     
     //iPhone/iPadの画面サイズに合わせて背景画像を拡大・縮小する
     [self setBackGroudImageName:@"back1.jpg"];
-    
-    self.currentScore = 0;
-    self.questionClassOBJ = [[Question alloc]init];
-    
 }
 
 - (void)didReceiveMemoryWarning {

--- a/DogCatch(ver1.01)/Controllers/NormalScreenViewController.h
+++ b/DogCatch(ver1.01)/Controllers/NormalScreenViewController.h
@@ -13,7 +13,6 @@
 #import"TimerClass.h"
 #import"TitleScreenViewController.h"
 #import "BaseViewController.h"
-#import "SDAudioPlayerManager.h"
 
 @interface NormalScreenViewController : BaseViewController<UIActionSheetDelegate>
 

--- a/DogCatch(ver1.01)/Controllers/NormalScreenViewController.m
+++ b/DogCatch(ver1.01)/Controllers/NormalScreenViewController.m
@@ -180,59 +180,8 @@
 //回答ボタンを押下時のイベント処理
 - (IBAction)pushedAnswerButton:(UIButton*)button
 {
-    
-    [_timer invalidate];
-    [AudioSingleton stopAudioWithKey:@"ゲーム中"];
-
-    self.clearView.hidden = NO;
-    self.clearViewImage.hidden = NO;
-    
-    //効果音、得点の増減、正解か不正解の値渡しを行う
-    if(button.tag == self.correctButtonTag + 1){
-        //正解の効果音を鳴らす
-        [AudioSingleton playAudioWithKey:@"正解"];
-        
-        //この問題での得点と、今までに得た得点を足して、総合計を算出する
-        self.currentScore = [self.questionClassOBJ evaluateScoreWithIsCorrect:YES remainTime:self.timeCount completion:^(NSInteger score) {
-            
-        }] + self.currentScore;
-        self.isCorrect = YES;
-        self.clearViewImage.image =[UIImage imageNamed:@"girl2.jpg"];
-        self.navBar.topItem.title = @"おめでとう!!";
-        
-    } else {
-        //不正解の効果音を鳴らす
-        [AudioSingleton playAudioWithKey:@"失敗"];
-        
-        //この問題での得点と、今までに得た得点を足して、総合計を算出する
-        self.currentScore = [self.questionClassOBJ evaluateScoreWithIsCorrect:NO remainTime:self.timeCount completion:^(NSInteger score) {
-            
-        }] + self.currentScore;
-        
-        self.isCorrect = NO;
-        self.clearViewImage.image =[UIImage imageNamed:@"girl1.jpg"];
-        self.navBar.topItem.title = @"残念!!";
-    }
-    
-    NSString *nowScoreStr = [[NSString alloc]initWithFormat:@"総得点 %zd",self.currentScore];
-    self.totalScore.text = nowScoreStr;
-    
-    self.dogButton1.enabled = NO;
-    self.dogButton2.enabled = NO;
-    self.dogButton3.enabled = NO;
-    self.dogButton4.enabled = NO;
-    self.dogButton5.enabled = NO;
-    
-    
-    self.gameStartButton.enabled = YES;
-    
-    //ボタンの円半径の設定を、画面変化に対応させる
-    //        sender.layer.cornerRadius = (self.view.bounds.size.width / 2) * 1.0f;
-    //            sender.layer.masksToBounds = YES;
-    
-    
+    [self clearGame:button];
 }
-
 
 //ハズレボタンの色とアクションを設定
 -(void)setButtonActionAndColor:(NSString*)action color:(NSString*)colorStr tag:(NSInteger)tag
@@ -439,6 +388,8 @@
      self.timeStr = [NSString stringWithFormat:@"残り時間 %05.2f",second];
     
     self.timeLabel.text = self.timeStr;
+    
+    [self stopTimerForTimeOut:self.timeCount];
 }
 
 -(void)timerStart
@@ -447,8 +398,72 @@
     if(![_timer isValid]){
         self.timer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(timer:) userInfo:nil repeats:YES];
     }
-    
 }
 
+//残り時間０以下でゲームを終了させる
+-(void)stopTimerForTimeOut:(CGFloat)count
+{
+    if (count <= 0) {
+        [self.timer invalidate];
+        [self clearGame:nil];
+    }
+}
+
+//ゲーム終了時の処理
+-(void)clearGame:(UIButton*)button
+{
+    //タイマーと音楽のストップ
+    [self.timer invalidate];
+    [AudioSingleton stopAudioWithKey:@"ゲーム中"];
+    
+    //ゲームクリアー画面のviewを表示させる
+    self.clearView.hidden = NO;
+    self.clearViewImage.hidden = NO;
+    
+    //効果音、得点の増減、正解か不正解の値渡しを行う
+    if(button.tag == self.correctButtonTag + 1){
+        //正解の効果音を鳴らす
+        [AudioSingleton playAudioWithKey:@"正解"];
+        
+        //この問題での得点と、今までに得た得点を足して、総合計を算出する
+        self.currentScore = [self.questionClassOBJ evaluateScoreWithIsCorrect:YES remainTime:self.timeCount completion:^(NSInteger score) {
+            
+        }] + self.currentScore;
+        self.isCorrect = YES;
+        self.clearViewImage.image =[UIImage imageNamed:@"girl2.jpg"];
+        self.navBar.topItem.title = @"おめでとう!!";
+        
+    } else {
+        //不正解の効果音を鳴らす
+        [AudioSingleton playAudioWithKey:@"失敗"];
+        
+        //この問題での得点と、今までに得た得点を足して、総合計を算出する
+        self.currentScore = [self.questionClassOBJ evaluateScoreWithIsCorrect:NO remainTime:self.timeCount completion:^(NSInteger score) {
+            
+        }] + self.currentScore;
+        
+        self.isCorrect = NO;
+        self.clearViewImage.image =[UIImage imageNamed:@"girl1.jpg"];
+        self.navBar.topItem.title = @"残念!!";
+    }
+    
+    //現在の得点をNSString化してLabelに表示
+    NSString *nowScoreStr = [[NSString alloc]initWithFormat:@"総得点 %zd",self.currentScore];
+    self.totalScore.text = nowScoreStr;
+    
+    //ボタンが何度も押されるのを防ぐため、enabledをnoに設定
+    self.dogButton1.enabled = NO;
+    self.dogButton2.enabled = NO;
+    self.dogButton3.enabled = NO;
+    self.dogButton4.enabled = NO;
+    self.dogButton5.enabled = NO;
+    
+    //スタートボタンのenabledをyesにし、次の問題に移れるようにする
+    self.gameStartButton.enabled = YES;
+    
+    //ボタンの円半径の設定を、画面変化に対応させる
+    //        sender.layer.cornerRadius = (self.view.bounds.size.width / 2) * 1.0f;
+    //            sender.layer.masksToBounds = YES;
+}
 
 @end

--- a/DogCatch(ver1.01)/Controllers/NormalScreenViewController.m
+++ b/DogCatch(ver1.01)/Controllers/NormalScreenViewController.m
@@ -41,23 +41,30 @@
 
 // scoreの累計を表示するLabel
 @property (nonatomic,weak) IBOutlet UILabel *totalScore;
-@property (nonatomic,weak) NSTimer *timer;
 
+//現在の得点
+@property (nonatomic,assign) NSInteger currentScore;
+
+//問題に正解したか？
+@property (nonatomic,assign) BOOL isCorrect;
+
+//正解ボタンのタグ番号
+@property (nonatomic,assign) NSInteger correctButtonTag;
+
+//設問パターンは、完全一致パターンですか？
+@property (nonatomic,assign) BOOL isCompletelyMatchingPattern;
+
+//タイマー
+@property (nonatomic,weak) NSTimer *timer;
+@property (nonatomic,assign) CGFloat timeCount;
+
+//Questionクラスのインスタンス
+@property (nonatomic,strong) Question *questionClassOBJ;
+
+@property (nonatomic,weak) AVAudioPlayer *player;
 @end
 
 @implementation NormalScreenViewController
-{
-    NSInteger correctButtonTag;
-    BOOL questionPattern;
-    
-    //タイマー
-//    __weak NSTimer *_timer;
-    float timeCount;
-    
-    NSInteger nowScore;
-    Question *questionClassOBJ;
-    BOOL _correctOrWrong;
-}
 
 #pragma mark - Public Methods
 #pragma mark - Private Methods
@@ -70,8 +77,8 @@
     //iPhone/iPadの画面サイズに合わせて背景画像を拡大・縮小する
     [self setBackGroudImageName:@"back1.jpg"];
     
-    nowScore = 0;
-    questionClassOBJ = [Question alloc];
+    self.currentScore = 0;
+    self.questionClassOBJ = [Question alloc];
 }
 
 - (void)didReceiveMemoryWarning {
@@ -142,10 +149,7 @@
     //女の子の顔画像を変更
     self.girlImage.image = [UIImage imageNamed:@"girl3.jpg"];
     
-    
-    
-    /*★☆★　動作確認用テスト★☆★*/
-    //ボタンのhiddenを解除
+    //ボタンのenabledを解除
     self.dogButton1.enabled = YES;
     self.dogButton2.enabled = YES;
     self.dogButton3.enabled = YES;
@@ -153,13 +157,15 @@
     self.dogButton5.enabled = YES;
     
     //今回の設問パターン（YES/NO）を決定
-    questionPattern = [self questionPattern:self.questionNumber];
+    self.isCompletelyMatchingPattern = [self.questionClassOBJ decisionQuestionPattern];
     
     //設問パターンをもとに、正解ボタンと失敗ボタンを生成し、同時に設問文の表示を行う
-    [self decidedQuestion:questionPattern label1:self.questionColorLabel label2:self.questionActionLabel];
+    [self decidedQuestion:self.isCompletelyMatchingPattern label1:self.questionColorLabel label2:self.questionActionLabel];
     
-    //音楽START！
-    [AudioSingleton playAudioWithKey:@"ゲーム中"];
+    //音楽START！（ループは無限）
+    self.player = [AudioSingleton playerWithKey:@"ゲーム中"];
+    self.player.numberOfLoops = -1;
+    [self.player play];
     
     //timer起動
 //    TimerClass *timerTest = [TimerClass alloc];
@@ -171,6 +177,7 @@
     self.navBar.topItem.title = @"犬をタッチしてつかまえてね!!";
 }
 
+//回答ボタンを押下時のイベント処理
 - (IBAction)pushedAnswerButton:(UIButton*)button
 {
     
@@ -181,15 +188,15 @@
     self.clearViewImage.hidden = NO;
     
     //効果音、得点の増減、正解か不正解の値渡しを行う
-    if(button.tag == correctButtonTag + 1){
+    if(button.tag == self.correctButtonTag + 1){
         //正解の効果音を鳴らす
         [AudioSingleton playAudioWithKey:@"正解"];
         
         //この問題での得点と、今までに得た得点を足して、総合計を算出する
-        nowScore = [questionClassOBJ evaluateScoreWithIsCorrect:YES remainTime:timeCount completion:^(NSInteger score) {
+        self.currentScore = [self.questionClassOBJ evaluateScoreWithIsCorrect:YES remainTime:self.timeCount completion:^(NSInteger score) {
             
-        }] + nowScore;
-        _correctOrWrong = YES;
+        }] + self.currentScore;
+        self.isCorrect = YES;
         self.clearViewImage.image =[UIImage imageNamed:@"girl2.jpg"];
         self.navBar.topItem.title = @"おめでとう!!";
         
@@ -198,16 +205,16 @@
         [AudioSingleton playAudioWithKey:@"失敗"];
         
         //この問題での得点と、今までに得た得点を足して、総合計を算出する
-        nowScore = [questionClassOBJ evaluateScoreWithIsCorrect:NO remainTime:timeCount completion:^(NSInteger score) {
+        self.currentScore = [self.questionClassOBJ evaluateScoreWithIsCorrect:NO remainTime:self.timeCount completion:^(NSInteger score) {
             
-        }] + nowScore;
+        }] + self.currentScore;
         
-        _correctOrWrong = NO;
+        self.isCorrect = NO;
         self.clearViewImage.image =[UIImage imageNamed:@"girl1.jpg"];
         self.navBar.topItem.title = @"残念!!";
     }
     
-    NSString *nowScoreStr = [[NSString alloc]initWithFormat:@"総得点 %zd",nowScore];
+    NSString *nowScoreStr = [[NSString alloc]initWithFormat:@"総得点 %zd",self.currentScore];
     self.totalScore.text = nowScoreStr;
     
     self.dogButton1.enabled = NO;
@@ -318,8 +325,8 @@
     
     
     //②正解ボタンをボタン1〜5のどれにするかをランダムに決める
-    correctButtonTag = arc4random() % 5;
-    NSInteger correctButtonTagNumber = [[allTag objectAtIndex:correctButtonTag]intValue];
+    self.correctButtonTag = arc4random() % 5;
+    NSInteger correctButtonTagNumber = [[allTag objectAtIndex:self.correctButtonTag]intValue];
     
     
     //③正解ボタンのアクションと色を設定する
@@ -328,7 +335,7 @@
     //④正解ボタンのアクションと色は、もう使わないのでarrayから削除する
     [allAction removeObjectAtIndex:correctAction];
     [allColor removeObjectAtIndex:correctColor];
-    [allTag removeObjectAtIndex:correctButtonTag];
+    [allTag removeObjectAtIndex:self.correctButtonTag];
     
     
     //⑤後の説明文表示に使うので、新たにNSMutableArrayを作成する（要素の０は「正しいアクション」要素の１は「正しい色」となる）
@@ -427,8 +434,8 @@
 -(void)timer:(NSTimer*)timer
 {
     
-    timeCount = timeCount - 0.01f;
-    float second = fmodf(timeCount,60);
+    self.timeCount = self.timeCount - 0.01f;
+    float second = fmodf(self.timeCount,60);
      self.timeStr = [NSString stringWithFormat:@"残り時間 %05.2f",second];
     
     self.timeLabel.text = self.timeStr;
@@ -436,7 +443,7 @@
 
 -(void)timerStart
 {
-    timeCount = 60;
+    self.timeCount = 60;
     if(![_timer isValid]){
         self.timer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(timer:) userInfo:nil repeats:YES];
     }

--- a/DogCatch(ver1.01)/Controllers/NormalScreenViewController.m
+++ b/DogCatch(ver1.01)/Controllers/NormalScreenViewController.m
@@ -61,7 +61,6 @@
 //Questionクラスのインスタンス
 @property (nonatomic,strong) Question *questionClassOBJ;
 
-@property (nonatomic,weak) AVAudioPlayer *player;
 @end
 
 @implementation NormalScreenViewController
@@ -162,10 +161,8 @@
     //設問パターンをもとに、正解ボタンと失敗ボタンを生成し、同時に設問文の表示を行う
     [self decidedQuestion:self.isCompletelyMatchingPattern label1:self.questionColorLabel label2:self.questionActionLabel];
     
-    //音楽START！（ループは無限）
-    self.player = [AudioSingleton playerWithKey:@"ゲーム中"];
-    self.player.numberOfLoops = -1;
-    [self.player play];
+    //音楽START！
+    [AudioSingleton playAudioWithKey:@"ゲーム中"];
     
     //timer起動
 //    TimerClass *timerTest = [TimerClass alloc];

--- a/DogCatch(ver1.01)/Controllers/TitleScreenViewController.h
+++ b/DogCatch(ver1.01)/Controllers/TitleScreenViewController.h
@@ -11,7 +11,6 @@
 #import "NormalScreenViewController.h"
 #import"TutorialScreenViewController.h"
 #import "BaseViewController.h"
-#import "SDAudioPlayerManager.h"
 
 @interface TitleScreenViewController : BaseViewController
 

--- a/DogCatch(ver1.01)/Controllers/TitleScreenViewController.m
+++ b/DogCatch(ver1.01)/Controllers/TitleScreenViewController.m
@@ -36,19 +36,11 @@
     //角丸設定
 //    [[self.buttonNormal layer] setCornerRadius:5.0];
 //    [self.buttonNormal setClipsToBounds:YES];
-    
 
-    //音楽の生成と再生
-    player = [AudioSingleton createPlayerWithFileName:@"c6.mp3" forKey:@"タイトル画面"];
-    //    player.numberOfLoops = -1;
-    [AudioSingleton playAudioWithKey:@"タイトル画面"];
-    
-    //以降の画面で必要な音楽データを、あらかじめコンテナに格納
-    [AudioSingleton createPlayerWithFileName:@"カジノ4.mp3" forKey:@"ゲーム中"];
-    [AudioSingleton createPlayerWithFileName:@"correct2.mp3" forKey:@"正解"];
-    [AudioSingleton createPlayerWithFileName:@"d6.mp3" forKey:@"失敗"];
-    [AudioSingleton createPlayerWithFileName:@"se9.wav" forKey:@"ゲームモード選択"];
-    [AudioSingleton createPlayerWithFileName:@"decision23.mp3" forKey:@"ルール説明ボタン"];
+    //音楽の生成と再生(ループは無限)
+    player = [AudioSingleton playerWithKey:@"タイトル画面"];
+    player.numberOfLoops = -1;
+    [player play];
 }
 
 

--- a/DogCatch(ver1.01)/Controllers/TitleScreenViewController.m
+++ b/DogCatch(ver1.01)/Controllers/TitleScreenViewController.m
@@ -38,9 +38,8 @@
 //    [self.buttonNormal setClipsToBounds:YES];
 
     //音楽の生成と再生(ループは無限)
-    player = [AudioSingleton playerWithKey:@"タイトル画面"];
-    player.numberOfLoops = -1;
-    [player play];
+    [AudioSingleton playAudioWithKey:@"タイトル画面"];
+
 }
 
 

--- a/DogCatch(ver1.01)/Controllers/TitleScreenViewController.m
+++ b/DogCatch(ver1.01)/Controllers/TitleScreenViewController.m
@@ -19,9 +19,6 @@
 @end
 
 @implementation TitleScreenViewController
-{
-    AVAudioPlayer *player;
-}
 
 #pragma mark - Public Methods
 #pragma mark - Private Methods
@@ -37,27 +34,14 @@
 //    [[self.buttonNormal layer] setCornerRadius:5.0];
 //    [self.buttonNormal setClipsToBounds:YES];
 
-    //音楽の生成と再生(ループは無限)
+    //音楽の生成と再生
     [AudioSingleton playAudioWithKey:@"タイトル画面"];
-
 }
-
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
-
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 
 //ゲームスタートボタンtap時のイベント
 - (IBAction)pushedGameStartButton:(UIButton*)button

--- a/DogCatch(ver1.01)/Controllers/TutorialScreenViewController.h
+++ b/DogCatch(ver1.01)/Controllers/TutorialScreenViewController.h
@@ -9,7 +9,6 @@
 #import <UIKit/UIKit.h>
 #import"TitleScreenViewController.h"
 #import "BaseViewController.h"
-#import "SDAudioPlayerManager.h"
 
 @interface TutorialScreenViewController : BaseViewController
 

--- a/DogCatch(ver1.01)/Models/PlistLoad.h
+++ b/DogCatch(ver1.01)/Models/PlistLoad.h
@@ -1,0 +1,17 @@
+//
+//  PlistLoad.h
+//  StrayDogOverOne
+//
+//  Created by RYO on 2015/06/24.
+//  Copyright (c) 2015年 RYO. All rights reserved.
+//
+// 音楽ファイルデータを登録した.plistを取り扱うクラス
+
+#import <Foundation/Foundation.h>
+#import "SDAudioPlayerManager.h"
+
+@interface PlistLoad : NSObject
+
++(void)loadPlist;
+
+@end

--- a/DogCatch(ver1.01)/Models/PlistLoad.h
+++ b/DogCatch(ver1.01)/Models/PlistLoad.h
@@ -12,6 +12,6 @@
 
 @interface PlistLoad : NSObject
 
-+(void)loadPlist;
++(void)loadAudioFilePlist;
 
 @end

--- a/DogCatch(ver1.01)/Models/PlistLoad.h
+++ b/DogCatch(ver1.01)/Models/PlistLoad.h
@@ -8,10 +8,12 @@
 // 音楽ファイルデータを登録した.plistを取り扱うクラス
 
 #import <Foundation/Foundation.h>
-#import "SDAudioPlayerManager.h"
 
 @interface PlistLoad : NSObject
 
+/**
+ plistからAudioFileを読み込み、SDAudioManagerを生成するメソッド
+ */
 +(void)loadAudioFilePlist;
 
 @end

--- a/DogCatch(ver1.01)/Models/PlistLoad.m
+++ b/DogCatch(ver1.01)/Models/PlistLoad.m
@@ -26,22 +26,6 @@
         
         //SDAudioPlayerManagerで音声ファイルをロード
         [[SDAudioPlayerManager sharedInstance] createPlayerWithFileName:fileName forKey:key];
-        
-        NSLog(@"---------------");
-        NSLog(@"fileName : %@",fileName);
-        NSLog(@"key : %@",key);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
 @end

--- a/DogCatch(ver1.01)/Models/PlistLoad.m
+++ b/DogCatch(ver1.01)/Models/PlistLoad.m
@@ -23,12 +23,12 @@
         NSString *fileName = audioInfo[@"fileName"];
         //key名
         NSString *key = audioInfo[@"key"];
-        
         //ループ設定
         NSNumber *loop = audioInfo[@"loop"];
         
         //SDAudioPlayerManagerで音声ファイルをロード
-        [[SDAudioPlayerManager sharedInstance] createPlayerWithFileName:fileName forKey:key loop:(NSInteger)loop];
+        [[SDAudioPlayerManager sharedInstance] createPlayerWithFileName:fileName
+                                                                 forKey:key loop:[loop intValue]];
     }
 }
 @end

--- a/DogCatch(ver1.01)/Models/PlistLoad.m
+++ b/DogCatch(ver1.01)/Models/PlistLoad.m
@@ -24,8 +24,11 @@
         //key名
         NSString *key = audioInfo[@"key"];
         
+        //ループ設定
+        NSNumber *loop = audioInfo[@"loop"];
+        
         //SDAudioPlayerManagerで音声ファイルをロード
-        [[SDAudioPlayerManager sharedInstance] createPlayerWithFileName:fileName forKey:key];
+        [[SDAudioPlayerManager sharedInstance] createPlayerWithFileName:fileName forKey:key loop:(NSInteger)loop];
     }
 }
 @end

--- a/DogCatch(ver1.01)/Models/PlistLoad.m
+++ b/DogCatch(ver1.01)/Models/PlistLoad.m
@@ -1,0 +1,47 @@
+//
+//  PlistLoad.m
+//  StrayDogOverOne
+//
+//  Created by RYO on 2015/06/24.
+//  Copyright (c) 2015年 RYO. All rights reserved.
+//
+
+#import "PlistLoad.h"
+
+
+@implementation PlistLoad
+
++ (void)loadPlist
+{
+    //plistをロードする
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"SDPreloadingAudioFiles" ofType:@"plist"];
+    NSArray *plists = [NSArray arrayWithContentsOfFile:path];
+    
+    //plistの中身を表示
+    for (NSDictionary *audioInfo in plists){
+        //音声ファイル名
+        NSString *fileName = audioInfo[@"fileName"];
+        //key名
+        NSString *key = audioInfo[@"key"];
+        
+        //SDAudioPlayerManagerで音声ファイルをロード
+        [[SDAudioPlayerManager sharedInstance] createPlayerWithFileName:fileName forKey:key];
+        
+        NSLog(@"---------------");
+        NSLog(@"fileName : %@",fileName);
+        NSLog(@"key : %@",key);
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+@end

--- a/DogCatch(ver1.01)/Models/PlistLoad.m
+++ b/DogCatch(ver1.01)/Models/PlistLoad.m
@@ -11,7 +11,7 @@
 
 @implementation PlistLoad
 
-+ (void)loadPlist
++ (void)loadAudioFilePlist
 {
     //plistをロードする
     NSString *path = [[NSBundle mainBundle] pathForResource:@"SDPreloadingAudioFiles" ofType:@"plist"];

--- a/DogCatch(ver1.01)/Models/PlistLoad.m
+++ b/DogCatch(ver1.01)/Models/PlistLoad.m
@@ -7,7 +7,7 @@
 //
 
 #import "PlistLoad.h"
-
+#import "SDAudioPlayerManager.h"
 
 @implementation PlistLoad
 

--- a/DogCatch(ver1.01)/Resources/SDPreloadingAudioFiles.plist
+++ b/DogCatch(ver1.01)/Resources/SDPreloadingAudioFiles.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/DogCatch(ver1.01)/Resources/SDPreloadingAudioFiles.plist
+++ b/DogCatch(ver1.01)/Resources/SDPreloadingAudioFiles.plist
@@ -3,36 +3,48 @@
 <plist version="1.0">
 <array>
 	<dict>
+		<key>loop</key>
+		<integer>-1</integer>
 		<key>fileName</key>
 		<string>c6.mp3</string>
 		<key>key</key>
 		<string>タイトル画面</string>
 	</dict>
 	<dict>
+		<key>loop</key>
+		<integer>-1</integer>
 		<key>fileName</key>
 		<string>カジノ4.mp3</string>
 		<key>key</key>
 		<string>ゲーム中</string>
 	</dict>
 	<dict>
+		<key>loop</key>
+		<integer>0</integer>
 		<key>fileName</key>
 		<string>correct2.mp3</string>
 		<key>key</key>
 		<string>正解</string>
 	</dict>
 	<dict>
+		<key>loop</key>
+		<integer>0</integer>
 		<key>fileName</key>
 		<string>d6.mp3</string>
 		<key>key</key>
 		<string>失敗</string>
 	</dict>
 	<dict>
+		<key>loop</key>
+		<integer>0</integer>
 		<key>fileName</key>
 		<string>se9.wav</string>
 		<key>key</key>
 		<string>ゲームモード選択</string>
 	</dict>
 	<dict>
+		<key>loop</key>
+		<integer>0</integer>
 		<key>fileName</key>
 		<string>decision23.mp3</string>
 		<key>key</key>

--- a/DogCatch(ver1.01)/Resources/SDPreloadingAudioFiles.plist
+++ b/DogCatch(ver1.01)/Resources/SDPreloadingAudioFiles.plist
@@ -1,5 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<array>
+	<dict>
+		<key>fileName</key>
+		<string>c6.mp3</string>
+		<key>key</key>
+		<string>タイトル画面</string>
+	</dict>
+	<dict>
+		<key>fileName</key>
+		<string>カジノ4.mp3</string>
+		<key>key</key>
+		<string>ゲーム中</string>
+	</dict>
+	<dict>
+		<key>fileName</key>
+		<string>correct2.mp3</string>
+		<key>key</key>
+		<string>正解</string>
+	</dict>
+	<dict>
+		<key>fileName</key>
+		<string>d6.mp3</string>
+		<key>key</key>
+		<string>失敗</string>
+	</dict>
+	<dict>
+		<key>fileName</key>
+		<string>se9.wav</string>
+		<key>key</key>
+		<string>ゲームモード選択</string>
+	</dict>
+	<dict>
+		<key>fileName</key>
+		<string>decision23.mp3</string>
+		<key>key</key>
+		<string>ルール説明ボタン</string>
+	</dict>
+</array>
 </plist>

--- a/DogCatch(ver1.01)/StrayDogOverOne-Prefix.pch
+++ b/DogCatch(ver1.01)/StrayDogOverOne-Prefix.pch
@@ -12,4 +12,7 @@
 // Include any system framework and library headers here that should be included in all compilation units.
 // You will also need to set the Prefix Header build setting of one or more of your targets to reference this file.
 
+#pragma mark - shingleton
+#import "SDAudioPlayerManager.h"
+
 #endif

--- a/DogCatch(ver1.01)/StrayDogOverOne-Prefix.pch
+++ b/DogCatch(ver1.01)/StrayDogOverOne-Prefix.pch
@@ -1,0 +1,15 @@
+//
+//  StrayDogOverOne-Prefix.pch
+//  StrayDogOverOne
+//
+//  Created by RYO on 2015/06/25.
+//  Copyright (c) 2015年 RYO. All rights reserved.
+//
+
+#ifndef StrayDogOverOne_StrayDogOverOne_Prefix_pch
+#define StrayDogOverOne_StrayDogOverOne_Prefix_pch
+
+// Include any system framework and library headers here that should be included in all compilation units.
+// You will also need to set the Prefix Header build setting of one or more of your targets to reference this file.
+
+#endif

--- a/StrayDogOverOne.xcodeproj/project.pbxproj
+++ b/StrayDogOverOne.xcodeproj/project.pbxproj
@@ -223,9 +223,17 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		2A93202D1B3B955C005039C7 /* config */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = config;
+			sourceTree = "<group>";
+		};
 		2ACC457E1B38EFE10064E416 /* Commons */ = {
 			isa = PBXGroup;
 			children = (
+				2A93202D1B3B955C005039C7 /* config */,
 				2ACC45A41B38F5690064E416 /* Categories */,
 				2ACC45A31B38F5590064E416 /* Utility */,
 				2ACC45A11B38F5230064E416 /* Singleton */,

--- a/StrayDogOverOne.xcodeproj/project.pbxproj
+++ b/StrayDogOverOne.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2ACC45DD1B38F73A0064E416 /* KodomoRounded.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC45DC1B38F73A0064E416 /* KodomoRounded.otf */; };
 		2ACC45E01B38F81B0064E416 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC45DF1B38F81B0064E416 /* Main.storyboard */; };
 		2AD222DA1B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2AD222D91B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist */; };
+		2AD222DD1B3A86E30098BAE0 /* PlistLoad.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */; };
 		2AF2C6F81B3A44180046BAD3 /* AlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF2C6F71B3A44180046BAD3 /* AlertView.m */; };
 		2AF2FDEA1AD60F0800E71856 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AF2FDE91AD60F0800E71856 /* AVFoundation.framework */; };
 		B66DB53DA80980756F3518CA /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F8819315EF35BDF02837D81 /* libPods.a */; };
@@ -124,6 +125,8 @@
 		2ACC45DC1B38F73A0064E416 /* KodomoRounded.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = KodomoRounded.otf; sourceTree = "<group>"; };
 		2ACC45DF1B38F81B0064E416 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		2AD222D91B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SDPreloadingAudioFiles.plist; sourceTree = "<group>"; };
+		2AD222DB1B3A86E30098BAE0 /* PlistLoad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlistLoad.h; sourceTree = "<group>"; };
+		2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlistLoad.m; sourceTree = "<group>"; };
 		2AF2C6F61B3A44180046BAD3 /* AlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlertView.h; sourceTree = "<group>"; };
 		2AF2C6F71B3A44180046BAD3 /* AlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AlertView.m; sourceTree = "<group>"; };
 		2AF2FDE91AD60F0800E71856 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -323,6 +326,8 @@
 			children = (
 				2ACC459E1B38F5100064E416 /* Question.h */,
 				2ACC459F1B38F5100064E416 /* Question.m */,
+				2AD222DB1B3A86E30098BAE0 /* PlistLoad.h */,
+				2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */,
 			);
 			name = Manager;
 			sourceTree = "<group>";
@@ -601,6 +606,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2AD222DD1B3A86E30098BAE0 /* PlistLoad.m in Sources */,
 				2ACC459C1B38F4720064E416 /* ScoreModel.m in Sources */,
 				2AF2C6F81B3A44180046BAD3 /* AlertView.m in Sources */,
 				2ACC45981B38F35A0064E416 /* CustomButton.m in Sources */,

--- a/StrayDogOverOne.xcodeproj/project.pbxproj
+++ b/StrayDogOverOne.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		2A3A3F0F1AD2373400F09768 /* DogCatch_ver1_01_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DogCatch_ver1_01_Tests.m; sourceTree = "<group>"; };
 		2A3A3F191AD2376600F09768 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		2A3A3F311AD2549900F09768 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		2A93202E1B3B99FD005039C7 /* StrayDogOverOne-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StrayDogOverOne-Prefix.pch"; sourceTree = "<group>"; };
 		2ACC45831B38F0700064E416 /* BaseViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseViewController.h; sourceTree = "<group>"; };
 		2ACC45841B38F0700064E416 /* BaseViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BaseViewController.m; sourceTree = "<group>"; };
 		2ACC45871B38F23A0064E416 /* TitleScreenViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TitleScreenViewController.h; sourceTree = "<group>"; };
@@ -125,8 +126,8 @@
 		2ACC45DC1B38F73A0064E416 /* KodomoRounded.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = KodomoRounded.otf; sourceTree = "<group>"; };
 		2ACC45DF1B38F81B0064E416 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		2AD222D91B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SDPreloadingAudioFiles.plist; sourceTree = "<group>"; };
-		2AD222DB1B3A86E30098BAE0 /* PlistLoad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlistLoad.h; sourceTree = "<group>"; };
-		2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlistLoad.m; sourceTree = "<group>"; };
+		2AD222DB1B3A86E30098BAE0 /* PlistLoad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlistLoad.h; path = ../Models/PlistLoad.h; sourceTree = "<group>"; };
+		2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PlistLoad.m; path = ../Models/PlistLoad.m; sourceTree = "<group>"; };
 		2AF2C6F61B3A44180046BAD3 /* AlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlertView.h; sourceTree = "<group>"; };
 		2AF2C6F71B3A44180046BAD3 /* AlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AlertView.m; sourceTree = "<group>"; };
 		2AF2FDE91AD60F0800E71856 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -202,6 +203,7 @@
 			children = (
 				2A3A3EEF1AD2373400F09768 /* Info.plist */,
 				2A3A3EF01AD2373400F09768 /* main.m */,
+				2A93202E1B3B99FD005039C7 /* StrayDogOverOne-Prefix.pch */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -226,6 +228,8 @@
 		2A93202D1B3B955C005039C7 /* config */ = {
 			isa = PBXGroup;
 			children = (
+				2AD222DB1B3A86E30098BAE0 /* PlistLoad.h */,
+				2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */,
 			);
 			name = config;
 			sourceTree = "<group>";
@@ -334,8 +338,6 @@
 			children = (
 				2ACC459E1B38F5100064E416 /* Question.h */,
 				2ACC459F1B38F5100064E416 /* Question.m */,
-				2AD222DB1B3A86E30098BAE0 /* PlistLoad.h */,
-				2AD222DC1B3A86E30098BAE0 /* PlistLoad.m */,
 			);
 			name = Manager;
 			sourceTree = "<group>";
@@ -746,6 +748,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_PREFIX_HEADER = "DogCatch(ver1.01)/$(PRODUCT_NAME)-Prefix.pch";
 				INFOPLIST_FILE = "DogCatch(ver1.01)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -762,6 +765,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				GCC_PREFIX_HEADER = "DogCatch(ver1.01)/$(PRODUCT_NAME)-Prefix.pch";
 				INFOPLIST_FILE = "DogCatch(ver1.01)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/StrayDogOverOne.xcodeproj/project.pbxproj
+++ b/StrayDogOverOne.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		2ACC45DA1B38F6B40064E416 /* カジノ4.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC45C31B38F6B40064E416 /* カジノ4.mp3 */; };
 		2ACC45DD1B38F73A0064E416 /* KodomoRounded.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC45DC1B38F73A0064E416 /* KodomoRounded.otf */; };
 		2ACC45E01B38F81B0064E416 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2ACC45DF1B38F81B0064E416 /* Main.storyboard */; };
+		2AD222DA1B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2AD222D91B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist */; };
 		2AF2C6F81B3A44180046BAD3 /* AlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF2C6F71B3A44180046BAD3 /* AlertView.m */; };
 		2AF2FDEA1AD60F0800E71856 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AF2FDE91AD60F0800E71856 /* AVFoundation.framework */; };
 		B66DB53DA80980756F3518CA /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F8819315EF35BDF02837D81 /* libPods.a */; };
@@ -122,6 +123,7 @@
 		2ACC45C31B38F6B40064E416 /* カジノ4.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "カジノ4.mp3"; sourceTree = "<group>"; };
 		2ACC45DC1B38F73A0064E416 /* KodomoRounded.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = KodomoRounded.otf; sourceTree = "<group>"; };
 		2ACC45DF1B38F81B0064E416 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		2AD222D91B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SDPreloadingAudioFiles.plist; sourceTree = "<group>"; };
 		2AF2C6F61B3A44180046BAD3 /* AlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlertView.h; sourceTree = "<group>"; };
 		2AF2C6F71B3A44180046BAD3 /* AlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AlertView.m; sourceTree = "<group>"; };
 		2AF2FDE91AD60F0800E71856 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -256,6 +258,7 @@
 				2ACC45DB1B38F73A0064E416 /* DogCatch_font */,
 				2ACC45AB1B38F6B40064E416 /* DogCatch_image */,
 				2ACC45BC1B38F6B40064E416 /* DogCatch_music */,
+				2AD222D91B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				2ACC45CC1B38F6B40064E416 /* girl3.jpg in Resources */,
 				2ACC45CB1B38F6B40064E416 /* girl2.jpg in Resources */,
 				2ACC45CF1B38F6B40064E416 /* koly.png in Resources */,
+				2AD222DA1B3A801D0098BAE0 /* SDPreloadingAudioFiles.plist in Resources */,
 				2ACC45C51B38F6B40064E416 /* balloon_down.png in Resources */,
 				2ACC45D61B38F6B40064E416 /* d6.mp3 in Resources */,
 				2ACC45C61B38F6B40064E416 /* balloon_up.png in Resources */,


### PR DESCRIPTION
## 概要
- アプリ内で使用する音楽ファイルをあらかじめリストで設定できるようにする
## 変更理由
- サウンド処理において、何を再生するかという情報をmodel側で制御したいため
## 変更点
- plistの作成
- 新規にPlistLoadクラスを作成
- 音楽データをPlistLoadクラスを用いて読み込む形に実装（AppDelegate内で呼び出し）
- （その他:残り時間が０秒になってもゲームが継続していたため、０秒でゲームが終了する処理を追加）
- （その他:easyModeでの変更内容を、normalModeにも反映）
## レビュー希望箇所
- 特になし
